### PR TITLE
Define GIT_SSH_MEMORY_CREDENTIALS for libgit2

### DIFF
--- a/test/tests/cred.js
+++ b/test/tests/cred.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 var path = require("path");
+var fs = require("fs");
 var local = path.join.bind(path, __dirname);
 
 describe("Cred", function() {
@@ -21,6 +22,23 @@ describe("Cred", function() {
       "");
 
     assert.ok(cred instanceof NodeGit.Cred);
+  });
+
+  it("can create ssh credentials using passed keys in memory", function() {
+    var publicKeyContents = fs.readFileSync(sshPublicKey, {
+      encoding: "ascii"
+    });
+    var privateKeyContents = fs.readFileSync(sshPrivateKey, {
+      encoding: "ascii"
+    });
+
+    return NodeGit.Cred.sshKeyMemoryNew(
+      "username",
+      publicKeyContents,
+      privateKeyContents,
+      "").then(function(cred) {
+        assert.ok(cred instanceof NodeGit.Cred);
+      });
   });
 
   it("can create credentials using plaintext", function() {

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -16,6 +16,7 @@
       "defines": [
         "GIT_THREADS",
         "GIT_SSH",
+        "GIT_SSH_MEMORY_CREDENTIALS",
         # Node's util.h may be accidentally included so use this to guard
         # against compilation error.
         "SRC_UTIL_H_",


### PR DESCRIPTION
Compile libgit2 with GIT_SSH_MEMORY_CREDENTIALS defined to allow
sshKeyMemoryNew to work.

Fixes #760
